### PR TITLE
fix: memory leak

### DIFF
--- a/plotlablib/include/plotlablib/zmqobjectprovider.h
+++ b/plotlablib/include/plotlablib/zmqobjectprovider.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017-2020 German Aerospace Center (DLR). 
+ * Copyright (C) 2017-2023 German Aerospace Center (DLR). 
  * Eclipse ADORe, Automated Driving Open Research https://eclipse.org/adore
  *
  * This program and the accompanying materials are made available under the 
@@ -10,6 +10,7 @@
  *
  * Contributors: 
  *   Daniel Heß - initial API and implementation
+ *   Matthias Nichting - minor fix of memory leak
  ********************************************************************************/
 
 #pragma once
@@ -69,6 +70,7 @@ public:
 		}catch(zmq::error_t err)
 		{
 			std::cout<<"error in ZMQObjectProvider::send: "<<err.what()<<"\n";
+			message.rebuild();
 		}		
 	}
 

--- a/plotlablib/include/plotlablib/zmqobjectsink.h
+++ b/plotlablib/include/plotlablib/zmqobjectsink.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017-2020 German Aerospace Center (DLR). 
+ * Copyright (C) 2017-2023 German Aerospace Center (DLR). 
  * Eclipse ADORe, Automated Driving Open Research https://eclipse.org/adore
  *
  * This program and the accompanying materials are made available under the 
@@ -10,6 +10,7 @@
  *
  * Contributors: 
  *   Daniel Heß - initial API and implementation
+ *   Matthias Nichting - fix of memory leak
  ********************************************************************************/
 
 #pragma once

--- a/plotlablib/include/plotlablib/zmqobjectsink.h
+++ b/plotlablib/include/plotlablib/zmqobjectsink.h
@@ -60,6 +60,7 @@ void* pthread_ZMQObjectSink_worker(void* that)
 		{
 			usleep(1);
 		}
+		msg.rebuild();
 		if(s->terminate)
 		{
 			break;


### PR DESCRIPTION
Repeated use of the message_t object with the socket_t::recv function without calling the message_t::rebuild function in between apparently leads to a memory leak. This PR solves this issue.